### PR TITLE
python: Don't fail outside of project

### DIFF
--- a/le-python.el
+++ b/le-python.el
@@ -298,8 +298,8 @@ it at one time."
 (defvar lispy--python-init-file nil)
 
 (defun lispy--python-poetry-name ()
-  (let ((pyproject
-         (file-name-directory (locate-dominating-file (buffer-file-name) "pyproject.toml"))))
+  (when-let* ((root (locate-dominating-file (buffer-file-name) "pyproject.toml"))
+              (pyproject (file-name-directory root)))
     (and (file-exists-p pyproject)
          (not (equal python-shell-interpreter "python"))
          (with-current-buffer (find-file-noselect pyproject)

--- a/le-python.el
+++ b/le-python.el
@@ -298,7 +298,8 @@ it at one time."
 (defvar lispy--python-init-file nil)
 
 (defun lispy--python-poetry-name ()
-  (when-let* ((root (locate-dominating-file (buffer-file-name) "pyproject.toml"))
+  (when-let* ((bfn (buffer-file-name))
+              (root (locate-dominating-file bfn "pyproject.toml"))
               (pyproject (file-name-directory root)))
     (and (file-exists-p pyproject)
          (not (equal python-shell-interpreter "python"))


### PR DESCRIPTION
File can be outside of project (so no root), may not use poetry/pyproject.toml or may be a buffer not visiting any file (e.g. as a playground during development).

Improves abo-abo/lispy#671.
Fixes abo-abo/lpy#47.